### PR TITLE
Remove default argument values from cpp

### DIFF
--- a/Hackscribble_MCP9804.cpp
+++ b/Hackscribble_MCP9804.cpp
@@ -243,7 +243,7 @@ void Hackscribble_MCP9804::configureAlert()
 }
 
 
-void Hackscribble_MCP9804::configureAlert(boolean action, uint16_t settings = ALERT_ALL | ALERT_LOW | ALERT_INTERRUPT)
+void Hackscribble_MCP9804::configureAlert(boolean action, uint16_t settings)
 {
   uint16_t current = _readRegister16(REG_CONFIG) & 0xFFF0;
   if (action == ENABLE)


### PR DESCRIPTION
Fixes:

```
Hackscribble_MCP9804.cpp:246:118: warning: default argument given for parameter 2 of 'void Hackscribble_MCP9804::configureAlert(boolean, uint16_t)' [-fpermissive]
 void Hackscribble_MCP9804::configureAlert(boolean action, uint16_t settings = ALERT_ALL | ALERT_LOW | ALERT_INTERRUPT)
                                                                                                                      ^
In file included from Hackscribble_MCP9804.cpp:24:0:
Hackscribble_MCP9804.h:99:8: note: previous specification in 'void Hackscribble_MCP9804::configureAlert(boolean, uint16_t)' here
   void configureAlert(boolean action, uint16_t settings = ALERT_ALL | ALERT_LOW | ALERT_INTERRUPT);
        ^
```